### PR TITLE
feat(UI): staggered animations, design tokens, and scroll polish

### DIFF
--- a/Outspire/Features/Academic/Views/ScoreView.swift
+++ b/Outspire/Features/Academic/Views/ScoreView.swift
@@ -26,12 +26,13 @@ struct ScoreView: View {
                 .transition(.opacity)
             } else if viewModel.isUnlocked {
                 mainContent
-                    .transition(.opacity)
+                    .transition(.opacity.combined(with: .offset(y: -10)))
             } else {
                 authenticationView
-                    .transition(.opacity)
+                    .transition(.opacity.combined(with: .offset(y: 10)))
             }
         }
+        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: viewModel.isUnlocked)
         .navigationTitle("Academic Grades")
         .toolbar {
             toolbarItems
@@ -285,6 +286,7 @@ struct ScoreView: View {
                     .padding(.top)
                     .id(viewModel.selectedTermId) // This ensures scrolling resets when term changes
                 }
+                .applyScrollEdgeEffect()
                 .refreshable {
                     // Reset animation state
                     animateIn = false

--- a/Outspire/Features/Account/Views/AccountV2View.swift
+++ b/Outspire/Features/Account/Views/AccountV2View.swift
@@ -5,6 +5,8 @@ struct AccountV2View: View {
     @Environment(\.presentToast) var presentToast
     @StateObject var viewModel = AccountV2ViewModel()
     @State private var showLogoutConfirmation = false
+    @State private var heroAppeared = false
+    @State private var animateLogin = false
     @FocusState private var focusedField: Field?
 
     enum Field { case code, password }
@@ -13,10 +15,13 @@ struct AccountV2View: View {
         Group {
             if viewModel.isAuthenticated {
                 loggedInView
+                    .transition(.opacity.combined(with: .scale(scale: 0.98)))
             } else {
                 loginView
+                    .transition(.opacity.combined(with: .scale(scale: 0.98)))
             }
         }
+        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: viewModel.isAuthenticated)
         .onChange(of: viewModel.errorMessage) { _, msg in showToast(msg, isError: true) }
         .onChange(of: viewModel.successMessage) { _, msg in showToast(msg, isError: false) }
     }
@@ -31,6 +36,8 @@ struct AccountV2View: View {
                     .font(.system(size: 56, weight: .light))
                     .foregroundStyle(AppColor.brand.gradient)
                     .shadow(color: AppColor.brand.opacity(0.3), radius: 12, y: 6)
+                    .symbolEffect(.bounce, value: heroAppeared)
+                    .staggeredEntry(index: 0, animate: animateLogin)
 
                 VStack(spacing: 6) {
                     Text("Welcome")
@@ -39,6 +46,7 @@ struct AccountV2View: View {
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }
+                .staggeredEntry(index: 1, animate: animateLogin)
 
                 // Input fields
                 VStack(spacing: 14) {
@@ -63,6 +71,7 @@ struct AccountV2View: View {
                         .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: AppRadius.md, style: .continuous))
                 }
                 .padding(.horizontal, 4)
+                .staggeredEntry(index: 2, animate: animateLogin)
 
                 // Sign in button
                 Button(action: login) {
@@ -86,12 +95,17 @@ struct AccountV2View: View {
                 }
                 .disabled(viewModel.isLoggingIn)
                 .buttonStyle(.pressableCard)
+                .staggeredEntry(index: 3, animate: animateLogin)
 
                 Spacer()
             }
             .padding(.horizontal, 24)
         }
         .navigationTitle("Account")
+        .onAppear {
+            heroAppeared = true
+            animateLogin = true
+        }
     }
 
     private var loggedInView: some View {

--- a/Outspire/Features/CAS/Views/ClubActivitiesView.swift
+++ b/Outspire/Features/CAS/Views/ClubActivitiesView.swift
@@ -328,10 +328,10 @@ struct ClubEmptyStateView: View {
                 .foregroundStyle(.quaternary)
                 .padding(.bottom, 8)
             Text("No activity records available")
-                .font(.headline)
+                .font(AppText.sectionTitle)
                 .foregroundStyle(.secondary)
             Text("Add a new activity using the + button")
-                .font(.subheadline)
+                .font(AppText.label)
                 .foregroundStyle(.tertiary)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal)
@@ -383,7 +383,7 @@ struct ActivityCardView: View {
             VStack(alignment: .leading, spacing: 6) {
                 HStack(alignment: .center, spacing: 8) {
                     Text(activity.C_Theme)
-                        .font(.headline)
+                        .font(AppText.sectionTitle)
                         .lineLimit(1)
                     Spacer()
                     if let status = activity.C_IsConfirm, status == 1 {
@@ -394,7 +394,7 @@ struct ActivityCardView: View {
                     }
                 }
                 Text("Date: \(formatDate(activity.C_Date))")
-                    .font(.subheadline)
+                    .font(AppText.label)
                     .foregroundStyle(.secondary)
             }
             HStack(spacing: 8) {
@@ -406,7 +406,7 @@ struct ActivityCardView: View {
                     .transition(.scale)
                 Spacer()
                 Text("Total: \(String(format: "%.1f", totalDuration))h")
-                    .font(.caption)
+                    .font(AppText.caption)
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
@@ -502,11 +502,10 @@ struct ReflectionView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Reflection")
-                .font(.subheadline)
-                .fontWeight(.medium)
+                .font(AppText.label)
                 .foregroundStyle(.secondary)
             Text(text)
-                .font(.body)
+                .font(AppText.body)
                 .lineLimit(isExpanded ? nil : 3)
                 .foregroundStyle(.primary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -519,7 +518,7 @@ struct ReflectionView: View {
                 } label: {
                     HStack(spacing: 4) {
                         Text(isExpanded ? "Show Less" : "Show More")
-                            .font(.caption)
+                            .font(AppText.caption)
                             .foregroundStyle(.blue)
                         Image(systemName: "chevron.down")
                             .font(.caption)

--- a/Outspire/Features/CAS/Views/ClubInfoView.swift
+++ b/Outspire/Features/CAS/Views/ClubInfoView.swift
@@ -513,10 +513,10 @@ struct ClubInfoView: View {
                     .padding(.bottom, 8)
 
                 Text("Club Information")
-                    .font(.headline)
+                    .font(AppText.sectionTitle)
 
                 Text("Select a category to view available clubs")
-                    .font(.subheadline)
+                    .font(AppText.label)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
             }
@@ -534,10 +534,10 @@ struct ClubInfoView: View {
                     .padding(.bottom, 8)
 
                 Text("No clubs available")
-                    .font(.headline)
+                    .font(AppText.sectionTitle)
 
                 Text("There are no clubs in this category")
-                    .font(.subheadline)
+                    .font(AppText.label)
                     .foregroundStyle(.secondary)
             }
             .frame(maxWidth: .infinity)
@@ -601,7 +601,7 @@ struct ClubInfoView: View {
             if !viewModel.members.isEmpty {
                 Text("(\(viewModel.members.count))")
                     .foregroundStyle(.secondary)
-                    .font(.subheadline)
+                    .font(AppText.label)
             }
         }
     }
@@ -968,7 +968,7 @@ struct MemberInfo: View {
             HStack(spacing: 4) {
                 // Member name
                 Text(member.S_Name)
-                    .font(.body)
+                    .font(AppText.body)
                     .fontWeight(
                         member.LeaderYes == "2" || member.LeaderYes == "1" ? .medium : .regular
                     )
@@ -977,7 +977,7 @@ struct MemberInfo: View {
                 // Nickname if available
                 if let nickname = member.S_Nickname, !nickname.isEmpty {
                     Text("(\(nickname))")
-                        .font(.subheadline)
+                        .font(AppText.label)
                         .foregroundStyle(.secondary)
                 }
 
@@ -999,7 +999,7 @@ struct MemberInfo: View {
 struct UserBadge: View {
     var body: some View {
         Text("You")
-            .font(.caption)
+            .font(AppText.caption)
             .foregroundStyle(.blue)
             .padding(.horizontal, 8)
             .padding(.vertical, 2)
@@ -1015,7 +1015,7 @@ struct LeadershipBadge: View {
 
     var body: some View {
         Text(isPresident ? "President" : "Vice President")
-            .font(.caption)
+            .font(AppText.caption)
             .foregroundStyle(isPresident ? .red : .orange)
             .padding(.horizontal, 8)
             .padding(.vertical, 2)
@@ -1033,7 +1033,7 @@ struct ClubSkeletonView: View {
             // Club info skeleton
             VStack(alignment: .leading, spacing: 12) {
                 Text("Club Information")
-                    .font(.headline)
+                    .font(AppText.sectionTitle)
                     .foregroundStyle(.clear)
 
                 ForEach(0 ..< 3, id: \.self) { _ in
@@ -1068,7 +1068,7 @@ struct ClubSkeletonView: View {
             // Member list skeleton
             VStack(alignment: .leading, spacing: 12) {
                 Text("Members")
-                    .font(.headline)
+                    .font(AppText.sectionTitle)
                     .foregroundStyle(.clear)
 
                 ForEach(0 ..< 5, id: \.self) { _ in

--- a/Outspire/Features/Main/Views/Cards/Cards.swift
+++ b/Outspire/Features/Main/Views/Cards/Cards.swift
@@ -1,10 +1,29 @@
 import CoreLocation
 import SwiftUI
 
+// MARK: - Breathe/Pulse Compatibility
+
+private struct BreatheOrPulseModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 18, *) {
+            content.symbolEffect(.breathe, isActive: true)
+        } else {
+            content.symbolEffect(.pulse, isActive: true)
+        }
+    }
+}
+
+private extension View {
+    func breatheOrPulse() -> some View {
+        modifier(BreatheOrPulseModifier())
+    }
+}
+
 // MARK: - Status Cards (Rich colored fills with depth)
 
 struct NoClassCard: View {
     let isDimmed: Bool
+    @State private var appeared = false
 
     init(isDimmed: Bool = false) {
         self.isDimmed = isDimmed
@@ -23,7 +42,8 @@ struct NoClassCard: View {
                     .font(.system(size: 40, weight: .medium))
                     .foregroundStyle(.white.opacity(0.9))
                     .symbolRenderingMode(.hierarchical)
-                    .symbolEffect(.pulse, isActive: true)
+                    .symbolEffect(.bounce, value: appeared)
+                    .onAppear { appeared = true }
 
                 Spacer().frame(height: AppSpace.xs)
 
@@ -58,7 +78,7 @@ struct WeekendCard: View {
                     .font(.system(size: 40, weight: .medium))
                     .foregroundStyle(.white.opacity(0.9))
                     .symbolRenderingMode(.hierarchical)
-                    .symbolEffect(.pulse, isActive: true)
+                    .breatheOrPulse()
 
                 Spacer().frame(height: AppSpace.xs)
 
@@ -101,7 +121,7 @@ struct HolidayModeCard: View {
                     .font(.system(size: 40, weight: .medium))
                     .foregroundStyle(.white.opacity(0.9))
                     .symbolRenderingMode(.hierarchical)
-                    .symbolEffect(.pulse, isActive: true)
+                    .breatheOrPulse()
 
                 Spacer().frame(height: AppSpace.xs)
 
@@ -552,7 +572,7 @@ struct SelfStudyPeriodCard: View {
                 .font(.system(size: 44))
                 .foregroundStyle(.purple)
                 .symbolRenderingMode(.hierarchical)
-                .symbolEffect(.pulse, isActive: true)
+                .breatheOrPulse()
 
             VStack(spacing: AppSpace.xxs) {
                 Text("Self-Study Period")
@@ -599,7 +619,7 @@ struct LunchBreakCard: View {
                 .font(.system(size: 44))
                 .foregroundStyle(.orange)
                 .symbolRenderingMode(.hierarchical)
-                .symbolEffect(.pulse, isActive: true)
+                .breatheOrPulse()
 
             VStack(spacing: AppSpace.xxs) {
                 Text("Lunch Break")

--- a/Outspire/Features/Main/Views/ExtraView.swift
+++ b/Outspire/Features/Main/Views/ExtraView.swift
@@ -33,6 +33,7 @@ struct ExtraView: View {
             }
         }
         .listStyle(.insetGrouped)
+        .applyScrollEdgeEffect()
         .navigationTitle("Explore")
         .navigationBarTitleDisplayMode(.large)
         .searchable(text: $query, prompt: "Search")

--- a/Outspire/Features/Main/Views/ScheduleSettingsSheet.swift
+++ b/Outspire/Features/Main/Views/ScheduleSettingsSheet.swift
@@ -40,8 +40,7 @@ struct ScheduleSettingsSheet: View {
                         .foregroundStyle(.secondary)
 
                     Text("Authentication Required")
-                        .font(.title2)
-                        .bold()
+                        .font(AppText.title)
 
                     Text("Please sign in to access schedule settings")
                         .foregroundStyle(.secondary)

--- a/Outspire/Features/Settings/Views/AboutView.swift
+++ b/Outspire/Features/Settings/Views/AboutView.swift
@@ -14,6 +14,9 @@ let appVersion = Bundle.main.releaseVersionNumber
 let appBuild = Bundle.main.buildVersionNumber
 
 struct AboutView: View {
+    @State private var animateEntrance = false
+    @State private var iconAppeared = false
+
     var body: some View {
         List {
             // Hero section
@@ -26,6 +29,9 @@ struct AboutView: View {
                             .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
                             .shadow(color: .black.opacity(0.15), radius: 12, y: 6)
                             .shadow(color: AppColor.brand.opacity(0.15), radius: 8, y: 4)
+                            .scaleEffect(iconAppeared ? 1.0 : 0.85)
+                            .opacity(iconAppeared ? 1.0 : 0)
+                            .animation(.spring(response: 0.6, dampingFraction: 0.7), value: iconAppeared)
                     }
 
                     VStack(spacing: 4) {
@@ -54,6 +60,7 @@ struct AboutView: View {
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 12)
             }
+            .staggeredEntry(index: 0, animate: animateEntrance)
 
             Section("Developer") {
                 Label {
@@ -66,12 +73,14 @@ struct AboutView: View {
                         .background(Color.blue.gradient, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
                 }
             }
+            .staggeredEntry(index: 1, animate: animateEntrance)
 
             Section("Data Sources") {
                 aboutRow("TSIMS for WFLA Int'l", icon: "server.rack", color: .indigo)
                 aboutRow("WFLMS.cn", icon: "globe", color: .teal)
                 aboutRow(" Weather", icon: "cloud.sun.fill", color: .orange)
             }
+            .staggeredEntry(index: 2, animate: animateEntrance)
 
             Section {
                 aboutLink("Feelin' Lucky", icon: "dice.fill", color: .pink, url: "https://object-battle.netlify.app/")
@@ -95,6 +104,11 @@ struct AboutView: View {
                     url: "https://github.com/at-wr/Outspire/"
                 )
             }
+            .staggeredEntry(index: 3, animate: animateEntrance)
+        }
+        .onAppear {
+            animateEntrance = true
+            iconAppeared = true
         }
         .navigationTitle("About")
         .contentMargins(.vertical, 10.0)

--- a/Outspire/Features/Settings/Views/SettingsView.swift
+++ b/Outspire/Features/Settings/Views/SettingsView.swift
@@ -6,6 +6,7 @@ struct SettingsView: View {
     @EnvironmentObject var sessionService: SessionService
     @State private var viewRefreshID = UUID()
     @State private var showOnboardingSheet = false
+    @State private var animateEntrance = false
 
     enum SettingsMenu: String, Hashable, CaseIterable {
         case account
@@ -26,6 +27,7 @@ struct SettingsView: View {
                     ProfileHeaderView()
                 }
             }
+            .staggeredEntry(index: 0, animate: animateEntrance)
 
             Section {
                 settingsLink(.general)
@@ -34,6 +36,7 @@ struct SettingsView: View {
                 settingsLink(.about)
                 settingsLink(.license)
             }
+            .staggeredEntry(index: 1, animate: animateEntrance)
 
             Section {
                 ShareLink(
@@ -107,6 +110,7 @@ struct SettingsView: View {
                     }
                 }
             }
+            .staggeredEntry(index: 2, animate: animateEntrance)
 
             #if DEBUG
                 Section("Debug Tools") {
@@ -121,9 +125,12 @@ struct SettingsView: View {
                             .foregroundStyle(.primary)
                     }
                 }
+                .staggeredEntry(index: 3, animate: animateEntrance)
             #endif
         }
         .id(viewRefreshID)
+        .applyScrollEdgeEffect()
+        .onAppear { animateEntrance = true }
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.large)
         .toolbar {


### PR DESCRIPTION
## Summary
- Staggered entrance animations on Settings, About, and Account views for a cascading reveal effect
- Spring-driven state transitions (opacity + scale/offset) for login/unlock flows
- AppText design token adoption across CAS and Club views, replacing raw `.font()` modifiers
- Symbol effect upgrades: `.breathe` (iOS 18+) with `.pulse` fallback; one-shot `.bounce` on appear
- Scroll edge effects on Score, Explore, and Settings lists
- Hero bounce + cascading login form animation on Account view

## Test plan
- [ ] Verify staggered section animations on Settings and About screens
- [ ] Check login view entrance animation and auth state transitions
- [ ] Confirm `.breathe` effect on iOS 18+ and `.pulse` fallback on older versions
- [ ] Verify scroll edge effects on scrollable lists
- [ ] Check typography consistency with AppText tokens in CAS/Club views