### PR TITLE
UI UPDATE: Add `SplashView.swift`

### DIFF
--- a/Outspire/OutspireApp.swift
+++ b/Outspire/OutspireApp.swift
@@ -42,7 +42,7 @@ struct OutspireApp: App {
 
     var body: some Scene {
         WindowGroup {
-            RootTabView()
+            SplashView() // <--- Updated: Set SplashView as the initial entry point
                 .tint(AppColor.brand)
                 .environmentObject(regionChecker)
                 .environmentObject(notificationManager)

--- a/Outspire/SplashView.swift
+++ b/Outspire/SplashView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct SplashView: View {
+    @State private var isActive = false
+    @State private var size = 0.8
+    @State private var opacity = 0.5
+
+    var body: some View {
+        if isActive {
+            // Replace with your actual Main ContentView
+            ContentView() 
+        } else {
+            VStack {
+                VStack(spacing: 20) {
+                    // Replace "sparkles" with your Outspire logo asset
+                    Image(systemName: "sparkles") 
+                        .font(.system(size: 80))
+                        .foregroundColor(.blue) // Use your primary brand color
+                    
+                    Text("Outspire")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                }
+                .scaleEffect(size)
+                .opacity(opacity)
+                .onAppear {
+                    withAnimation(.easeIn(duration: 1.0)) {
+                        self.size = 1.0
+                        self.opacity = 1.0
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color(UIColor.systemBackground))
+            .onAppear {
+                // Simulates loading time before transitioning to the main app
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                    withAnimation {
+                        self.isActive = true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Outspire/SplashView.swift
+++ b/Outspire/SplashView.swift
@@ -2,44 +2,43 @@ import SwiftUI
 
 struct SplashView: View {
     @State private var isActive = false
-    @State private var size = 0.8
-    @State private var opacity = 0.5
+    @State private var opacity = 0.0
 
     var body: some View {
         if isActive {
-            // Replace with your actual Main ContentView
-            ContentView() 
+            RootTabView()
         } else {
-            VStack {
-                VStack(spacing: 20) {
-                    // Replace "sparkles" with your Outspire logo asset
-                    Image(systemName: "sparkles") 
-                        .font(.system(size: 80))
-                        .foregroundColor(.blue) // Use your primary brand color
-                    
-                    Text("Outspire")
-                        .font(.largeTitle)
-                        .fontWeight(.bold)
-                }
-                .scaleEffect(size)
-                .opacity(opacity)
-                .onAppear {
-                    withAnimation(.easeIn(duration: 1.0)) {
-                        self.size = 1.0
-                        self.opacity = 1.0
-                    }
-                }
+            VStack(spacing: 16) {
+                Text("Outspire")
+                    .font(.system(size: 52, weight: .bold, design: .rounded))
+                    .foregroundColor(.primary)
+
+                Text("All-in-one Campus App for WFLA")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
             }
+            .opacity(opacity)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color(UIColor.systemBackground))
             .onAppear {
-                // Simulates loading time before transitioning to the main app
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                withAnimation(.easeIn(duration: 1.0)) {
+                    opacity = 1.0
+                }
+
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
                     withAnimation {
-                        self.isActive = true
+                        isActive = true
                     }
                 }
             }
         }
+    }
+}
+
+struct SplashView_Previews: PreviewProvider {
+    static var previews: some View {
+        SplashView()
     }
 }


### PR DESCRIPTION
## Overview
This PR introduces a native SwiftUI splash screen to improve the app's launch experience, providing a smooth visual transition before loading the main app interface.

## Changes Made
* **Added `SplashView.swift`**: Created a new initial view featuring the Outspire branding and the subtitle "All-in-one Campus App for WFLA". It includes a 1.0-second fade-in animation and automatically transitions to the main app screen after 2.5 seconds.
* **Updated `OutspireApp.swift`**: 
  * Swapped the initial entry point inside the `WindowGroup` from `RootTabView()` to `SplashView()`.
  * Preserved all environment objects, URL scheme handlers, and lifecycle modifiers (`.onAppear`, `.onChange`, etc.) by attaching them to the new root view, ensuring state management cascades correctly once the main app loads.

## Notes
* The splash screen utilizes SwiftUI state transitions to seamlessly hand off to `RootTabView()` upon completion of the animation sequence.